### PR TITLE
fix(various): bugs and parse-impl

### DIFF
--- a/packages/copper/Cargo.toml
+++ b/packages/copper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pistonite-cu"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "Battery-included common utils to speed up development of rust tools"
 repository = "https://github.com/Pistonite/cu"
@@ -106,6 +106,7 @@ json-preserve-order = ["json", "serde_json/preserve_order"]
 yaml = ["parse", "serde", "dep:serde_yaml_ng"]
 toml = ["parse", "serde", "dep:toml"]
 toml-preserve-order = ["toml", "toml/preserve_order"]
+parse-impl = ["parse"] # re-export implementation details, such as toml::ser
 
 # Internally used to document where nightly feature is used
 # (in particular, doc_cfg)

--- a/packages/copper/Taskfile.yml
+++ b/packages/copper/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
         PACKAGE: pistonite-cu
         FEATURES: full
     - task: cargo:fmt-check
-    - cmd: echo "checking default feature"; (grep "^default = \[\]$" Cargo.toml || rg "^default = \[\]$" Cargo.toml)
+    - cmd: echo "checking default feature"; grep "^default = \[\]$" Cargo.toml
 
   fix:
     - task: cargo:fmt-fix

--- a/packages/copper/src/cli/flags.rs
+++ b/packages/copper/src/cli/flags.rs
@@ -285,11 +285,29 @@ fn handle_result(start: Instant, result: crate::Result<()>) -> std::process::Exi
             // so user is directed to see what is the most important
             crate::debug!("finished in {elapsed:.2}s");
         }
+        reset_color();
         std::process::ExitCode::FAILURE
     } else {
         if crate::lv::is_print_time_enabled() {
             crate::info!("finished in {elapsed:.2}s");
         }
+        reset_color();
         std::process::ExitCode::SUCCESS
+    }
+}
+
+fn reset_color() {
+    use std::io::IsTerminal as _;
+    use std::io::Write as _;
+    let mut stdout = std::io::stdout();
+    if stdout.is_terminal() {
+        let _ = write!(stdout, "\x1b[0m");
+        let _ = stdout.flush();
+        return;
+    }
+    let mut stderr = std::io::stderr();
+    if stderr.is_terminal() {
+        let _ = write!(stderr, "\x1b[0m");
+        let _ = stderr.flush();
     }
 }

--- a/packages/copper/src/errhand.rs
+++ b/packages/copper/src/errhand.rs
@@ -175,7 +175,7 @@ macro_rules! unimplemented {
         return Err($crate::Error::msg("not implemented"));
     }};
     ($($args:tt)*) => {{
-        let msg = format!("{}", format_args!($(args)*));
+        let msg = format!("{}", format_args!($($args)*));
         $crate::trace!("unexpected: not implemented reached: {msg}");
         $crate::bail!("not implemented: {msg}")
     }}

--- a/packages/copper/src/parse/json_impl.rs
+++ b/packages/copper/src/parse/json_impl.rs
@@ -30,6 +30,8 @@
 /// ```
 pub mod json {
     use crate::{Context, Parse};
+    #[cfg(feature = "parse-impl")]
+    pub use ::serde_json::{de, error, map, ser, value};
     use serde::{Deserialize, Serialize};
     pub use serde_json::{Map, Number, Value};
 

--- a/packages/copper/src/parse/toml_impl.rs
+++ b/packages/copper/src/parse/toml_impl.rs
@@ -41,6 +41,8 @@ pub mod toml {
     use crate::{Context, Parse};
     pub use ::toml::value::{Date, Datetime, Offset, Time};
     pub use ::toml::{Spanned, Table, Value, value::Array as Vec};
+    #[cfg(feature = "parse-impl")]
+    pub use ::toml::{de, map, ser, value};
     use serde::{Deserialize, Serialize};
 
     /// TOML parse delegate. See [`toml`](module@crate::toml)


### PR DESCRIPTION
- Clear formatting on exit
- Unimplemented macro didn't work
- new feature flag `parse-impl` to expose internal modules from toml and json